### PR TITLE
Add ArchiveBox to Backup Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ _Note that it is pretty redundant to use uBlock Origin + Privacy Badger as it se
 * [Cronopete](https://gitlab.com/rastersoft/cronopete) – A backup utility for Linux, modeled after Apple's Time Machine.
 * [BorgBackup](https://www.borgbackup.org) – A deduplicating archiver with compression and encryption.
 * [UrBackup](https://www.urbackup.org) – An open Source client/server backup system.
+* [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox) - A self-hosted internet archiving solution to preserve websites offline.
 
 ## Gaming
 

--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ _Note that it is pretty redundant to use uBlock Origin + Privacy Badger as it se
 * [Cronopete](https://gitlab.com/rastersoft/cronopete) – A backup utility for Linux, modeled after Apple's Time Machine.
 * [BorgBackup](https://www.borgbackup.org) – A deduplicating archiver with compression and encryption.
 * [UrBackup](https://www.urbackup.org) – An open Source client/server backup system.
-* [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox) - A self-hosted internet archiving solution to preserve websites offline.
+* [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox) – A self-hosted internet archiving solution to preserve websites offline.
 
 ## Gaming
 


### PR DESCRIPTION
ArchiveBox is entirely open-source/self-hosted, collects no analytics, and exists to help people save their bookmarks & content off social media for anti-censorship, digital preservation, and privacy reasons.

https://github.com/ArchiveBox/ArchiveBox