### PR TITLE
Add NoteGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ _Note that it is pretty redundant to use uBlock Origin + Privacy Badger as it se
 * [QOwnNotes](https://www.qownnotes.org) – An open source markdown note taking with Nextcloud / ownCloud integration.
 * [Boost Note](https://boostnote.io) – An open source Markdown editor for developers.
 * [Paperwork](https://paperwork.cloud) – An open-source, self-hosted alternative to services like Evernote, OneNote or Google Keep.
+* [NoteGen](https://notegen.top/) – An open-source, local-first note-taking app that keeps written notes as Markdown files in a user-selected workspace.
 
 ## Markdown editors
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ _Note that it is pretty redundant to use uBlock Origin + Privacy Badger as it se
 * [QOwnNotes](https://www.qownnotes.org) – An open source markdown note taking with Nextcloud / ownCloud integration.
 * [Boost Note](https://boostnote.io) – An open source Markdown editor for developers.
 * [Paperwork](https://paperwork.cloud) – An open-source, self-hosted alternative to services like Evernote, OneNote or Google Keep.
-* [NoteGen](https://notegen.top/) – An open-source, local-first note-taking app that keeps written notes as Markdown files in a user-selected workspace.
+* [NoteGen](https://notegen.top) – An open-source, local-first note-taking app that writes notes as Markdown files in a user-selected workspace.
 
 ## Markdown editors
 


### PR DESCRIPTION
## Summary

Add NoteGen to the Note-taking section.

NoteGen is open source and local-first. Written notes are kept as ordinary Markdown files in a workspace selected by the user, and cloud synchronization is optional and user-controlled.

This description intentionally focuses on verifiable local data ownership and does not claim end-to-end encryption.

## Validation

- Confirmed NoteGen is not already listed.
- Confirmed the official site and source repository are accessible.
- Checked the Markdown diff for formatting errors.

